### PR TITLE
Extract out the PageHeader component for customizing

### DIFF
--- a/scaffold/src/common/nav.js
+++ b/scaffold/src/common/nav.js
@@ -18,19 +18,16 @@ export const menus = [{
     name: '分析页',
     path: 'analysis',
     component: Analysis,
-    pageHeader: null,  // 去掉页面标题通栏
     icon: 'setting',
   }, {
     name: '监控页',
     path: 'monitor',
     component: Monitor,
-    pageHeader: null,  // 去掉页面标题通栏
     icon: 'setting',
   }, {
     name: '工作台',
     path: 'workplace',
     component: Workplace,
-    pageHeader: null,  // 去掉页面标题通栏
     icon: 'setting',
   }],
 }, {

--- a/scaffold/src/components/PageHeader/index.js
+++ b/scaffold/src/components/PageHeader/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Breadcrumb } from 'antd';
 import { Link } from 'dva/router';
 import styles from './index.less';
@@ -10,14 +11,29 @@ function itemRender(route, params, routes, paths) {
     : <Link to={paths.join('/')}>{route.breadcrumbName}</Link>;
 }
 
-export default ({ routes, params, title, children }) => {
-  if (children === null) {
-    return children;
+export default class PageHeader extends Component {
+  static contextTypes = {
+    routes: PropTypes.array,
+    params: PropTypes.object,
   }
-  return (
-    <div className={styles.pageHeader}>
-      <Breadcrumb routes={routes} params={params} itemRender={itemRender} />
-      <h1>{title}</h1>
-    </div>
-  );
-};
+  getBreadcrumbProps() {
+    return {
+      routes: this.props.routes || this.context.routes,
+      params: this.props.params || this.context.params,
+    };
+  }
+  render() {
+    const { routes, params } = this.getBreadcrumbProps();
+    const { title, children } = this.props;
+    const defaultTitle = routes[routes.length - 1].breadcrumbName;
+    return (
+      <div>
+        <div className={styles.pageHeader}>
+          <Breadcrumb routes={routes} params={params} itemRender={itemRender} />
+          <h1>{title || defaultTitle}</h1>
+        </div>
+        {children ? <div className={styles.content}>{children}</div> : null}
+      </div>
+    );
+  }
+}

--- a/scaffold/src/layouts/BasicLayout.js
+++ b/scaffold/src/layouts/BasicLayout.js
@@ -80,7 +80,7 @@ class BasicLayout extends React.Component {
     });
   }
   render() {
-    const { routes, children, main, currentUser } = this.props;
+    const { routes, children, currentUser } = this.props;
     const { collapsed } = this.state;
     const pageTitle = routes[routes.length - 1].breadcrumbName;
 
@@ -145,7 +145,7 @@ class BasicLayout extends React.Component {
               </div>
             </Header>
             <Content style={{ margin: 24, minHeight: 280 }}>
-              {main || children}
+              {children}
             </Content>
           </Layout>
         </Layout>

--- a/scaffold/src/layouts/BasicLayout.js
+++ b/scaffold/src/layouts/BasicLayout.js
@@ -1,10 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Layout, Menu, Icon, Tooltip, Avatar, Dropdown } from 'antd';
 import DocumentTitle from 'react-document-title';
 import { connect } from 'dva';
 import { Link } from 'dva/router';
 import styles from './BasicLayout.less';
-import PageHeader from '../components/PageHeader';
 import HeaderSearch from '../components/HeaderSearch';
 import NotificationIcon from '../components/NotificationIcon';
 import { menus } from '../common/nav';
@@ -13,10 +13,18 @@ const { Header, Sider, Content } = Layout;
 const { SubMenu } = Menu;
 
 class BasicLayout extends React.Component {
+  static childContextTypes = {
+    routes: PropTypes.array,
+    params: PropTypes.object,
+  }
   state = {
     collapsed: false,
     mode: 'inline',
   };
+  getChildContext() {
+    const { routes, params } = this.props;
+    return { routes, params };
+  }
   componentDidMount() {
     this.props.dispatch({
       type: 'user/fetchCurrent',
@@ -72,7 +80,7 @@ class BasicLayout extends React.Component {
     });
   }
   render() {
-    const { routes, params, children, header, main, currentUser } = this.props;
+    const { routes, children, main, currentUser } = this.props;
     const { collapsed } = this.state;
     const pageTitle = routes[routes.length - 1].breadcrumbName;
 
@@ -136,10 +144,7 @@ class BasicLayout extends React.Component {
                 </Dropdown>
               </div>
             </Header>
-            <PageHeader title={pageTitle} routes={routes} params={params}>
-              {header}
-            </PageHeader>
-            <Content style={{ margin: 24, minHeight: 280, overflow: 'visible' }}>
+            <Content style={{ margin: 24, minHeight: 280 }}>
               {main || children}
             </Content>
           </Layout>

--- a/scaffold/src/layouts/PageHeaderLayout.js
+++ b/scaffold/src/layouts/PageHeaderLayout.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import PageHeader from '../components/PageHeader';
+
+export default ({ children, ...restProps }) => (
+  <div style={{ margin: -24 }}>
+    <PageHeader {...restProps} />
+    {children ? <div style={{ margin: 24 }}>{children}</div> : null}
+  </div>
+);

--- a/scaffold/src/router.js
+++ b/scaffold/src/router.js
@@ -8,15 +8,6 @@ function getRoutes(data, level = 0) {
     if (item.children) {
       children = getRoutes(item.children, level + 1);
     }
-    const componentProps = {};
-    if ('pageHeader' in item) {
-      componentProps.components = {
-        header: item.pageHeader,
-        main: item.component,
-      };
-    } else {
-      componentProps.component = item.component;
-    }
     let homePageRedirect;
     if (level === 1 && i === 0) {
       let indexPath;
@@ -33,7 +24,7 @@ function getRoutes(data, level = 0) {
         key={item.key || item.path || ''}
         path={item.path}
         breadcrumbName={item.name}
-        {...componentProps}
+        component={item.component}
       >
         {homePageRedirect}
         {children}

--- a/scaffold/src/routes/Forms/BasicForms.js
+++ b/scaffold/src/routes/Forms/BasicForms.js
@@ -4,11 +4,12 @@ import { Card } from 'antd';
 import HorizontalForm from './HorizontalForm';
 import MultipleColForm from './MultipleColForm';
 import StandardForm from './StandardForm';
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import styles from './style.less';
 
 function BasicForms() {
   return (
-    <div>
+    <PageHeaderLayout>
       <Card title="横向表单" className={styles.card} bordered={false}>
         <HorizontalForm />
       </Card>
@@ -18,7 +19,7 @@ function BasicForms() {
       <Card title="标准表单" className={styles.card} bordered={false}>
         <StandardForm />
       </Card>
-    </div>
+    </PageHeaderLayout>
   );
 }
 

--- a/scaffold/src/routes/List/TableList.js
+++ b/scaffold/src/routes/List/TableList.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'dva';
 import { Card, Row, Col, Form, Input, Select, Icon, Button, Dropdown, Menu, InputNumber, DatePicker } from 'antd';
 import StandardTable from '../../components/StandardTable';
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 
 import styles from './TableList.less';
 
@@ -131,7 +132,7 @@ class TableList extends Component {
     );
 
     return (
-      <div>
+      <PageHeaderLayout>
         <Card noHovering>
           <div className={styles.tableList}>
             <div className={styles.tableListForm}>
@@ -205,7 +206,7 @@ class TableList extends Component {
             />
           </div>
         </Card>
-      </div>
+      </PageHeaderLayout>
     );
   }
 }

--- a/scaffold/src/routes/ListPage.js
+++ b/scaffold/src/routes/ListPage.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { connect } from 'dva';
+import PageHeaderLayout from '../layouts/PageHeaderLayout';
 
 function Forms() {
   return (
-    <div>456</div>
+    <PageHeaderLayout>
+      456
+    </PageHeaderLayout>
   );
 }
 

--- a/scaffold/src/routes/Profile.js
+++ b/scaffold/src/routes/Profile.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { connect } from 'dva';
+import PageHeaderLayout from '../layouts/PageHeaderLayout';
 
 function Forms() {
   return (
-    <div>789</div>
+    <PageHeaderLayout>
+      789
+    </PageHeaderLayout>
   );
 }
 


### PR DESCRIPTION
1. 把 PageHeader 从 nav.js 里拿出来，允许页面自定义。
2. 页面里没有写 PageHeader 的，就没有页头。
3. 封装了一个 PageHeaderLayout，可以如下方式使用：
   ```
   <PageHeaderLayout>
     页面内容
   </PageHeaderLayout>
   ```
   PageHeaderLayout 的参数和 PageHeader 一致，PageHeaderLayout 支持了传 children 作为页面内容，以及处理了无页头内容的 margin 适配问题。
4. PageHeader 读取 context 里的 routes 和 params 信息以默认生成面包屑和标题，可被覆盖。