### PR TITLE
Add FooterToolbar

### DIFF
--- a/scaffold/src/components/FooterToolbar/index.js
+++ b/scaffold/src/components/FooterToolbar/index.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styles from './index.less';
+
+export default class FooterToolbar extends Component {
+  static contextTypes = {
+    layoutCollapsed: PropTypes.bool,
+  };
+  state = {
+    width: '',
+  };
+  componentDidMount() {
+    this.syncWidth();
+  }
+  componentWillReceiveProps() {
+    this.syncWidth();
+  }
+  syncWidth() {
+    const sider = document.querySelectorAll('.ant-layout-sider')[0];
+    if (sider) {
+      this.setState({
+        width: `calc(100% - ${sider.style.width})`,
+      });
+    }
+  }
+  render() {
+    const { children, style, className, extra, ...restProps } = this.props;
+    return (
+      <div
+        className={classNames(className, styles.toolbar)}
+        ref={this.getRefNode}
+        style={{
+          width: this.state.width,
+          ...style,
+        }}
+        {...restProps}
+      >
+        <div className={styles.left}>{extra}</div>
+        <div className={styles.right}>{children}</div>
+      </div>
+    );
+  }
+}

--- a/scaffold/src/components/FooterToolbar/index.less
+++ b/scaffold/src/components/FooterToolbar/index.less
@@ -1,0 +1,25 @@
+@import "~antd/lib/style/themes/default.less";
+
+.toolbar {
+  position: fixed;
+  width: 100%;
+  bottom: 0;
+  right: 0;
+  height: 56px;
+  line-height: 56px;
+  box-shadow: @shadow-1-up;
+  background: #fff;
+  padding: 0 28px;
+
+  .left {
+    float: left;
+  }
+
+  .right {
+    float: right;
+  }
+
+  button + button {
+    margin-left: 8px;
+  }
+}

--- a/scaffold/src/components/FooterToolbar/index.md
+++ b/scaffold/src/components/FooterToolbar/index.md
@@ -1,0 +1,9 @@
+---
+category: Components
+type: General
+title: FooterToolbar
+subtitle: 底部固定工具栏
+cols: 1
+---
+
+## API

--- a/scaffold/src/routes/Forms/LongForm.js
+++ b/scaffold/src/routes/Forms/LongForm.js
@@ -1,16 +1,20 @@
 import React from 'react';
-import { connect } from 'dva';
-import { Card } from 'antd';
+import { Card, Button } from 'antd';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import FooterToolbar from '../../components/FooterToolbar';
 
 function LongForm() {
   return (
-    <PageHeaderLayout title="长表单">
+    <PageHeaderLayout title="长表单" content="在后台页面中，大批量的数据修改和提交是很常见的情况。">
       <Card bordered={false}>
-        ...
+        111
       </Card>
+      <FooterToolbar>
+        <Button>取消</Button>
+        <Button type="primary">提交</Button>
+      </FooterToolbar>
     </PageHeaderLayout>
   );
 }
 
-export default connect()(LongForm);
+export default LongForm;


### PR DESCRIPTION
https://github.com/ant-design/test/issues/7

- 文档和演示后面补。
- #7 里提到的宽度同步方案是不可行的，这里强制和侧边栏宽度保持绑定了。