### PR TITLE
文档更新：构建发布、图表、mock、布局、服务端

### DIFF
--- a/docs/spec/build-and-publish.md
+++ b/docs/spec/build-and-publish.md
@@ -32,7 +32,7 @@ app.get('/*', function (req, res) {
 });
 ```
 
-[egg](http://chair.alibaba-inc.com/) 的例子
+[egg](https://eggjs.org/) 的例子
 ```
 // controller
 exports.index = function* () {

--- a/docs/spec/build-and-publish.md
+++ b/docs/spec/build-and-publish.md
@@ -3,14 +3,14 @@ order: 12
 title: 构建和发布
 ---
 
-构建和发布
-
 ---
 
-## 段落标题一
+## 构建
 
-段落一
+由于 Ant Design Pro 底层使用的 [roadhog](https://github.com/sorrycc/roadhog) 工具，已经将复杂的流程封装完毕，对于大部分场景，构建打包文件只需要一个命令 `roadhog build`，构建打包成功之后，会在根目录生成 `dist` 文件夹，里面就是构建打包好的文件，通常是 `index.js`、`index.css`、`index.html` 三个静态文件。
 
-## 段落标题二
+不过你如果需要自定义构建，比如指定 `dist` 目录等，则需要通过 `.roadhogrc` 进行配置，详情参看：[roadhog 配置](https://github.com/sorrycc/roadhog#配置)。
 
-段落二
+## 发布
+
+对于发布来讲，只需要将最终生成的静态文件，也就是通常情况下 `dist` 文件夹的静态文件发布到你的 cdn 或者静态服务器即可，需要注意的是其中的 `index.html` 通常会是你后台服务的入口页面，在确定了 js 和 css 的静态之后可能需要改变页面的引入路径。

--- a/docs/spec/build-and-publish.md
+++ b/docs/spec/build-and-publish.md
@@ -21,6 +21,8 @@ Ant Design Pro 中，前端路由使用的是 [React Router](https://github.com/
 
 两者的区别简单来说是对路由方式的处理不一样，`hashHistory` 是以 `#` 后面的路径进行处理，通过 [HTML 5 History](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 进行前端路由管理，而 `browserHistory` 则是类似我们通常的页面访问路径，并没有 `#`，通过服务端的配置，能够访问指定的 url 都定向到当前页面，从而能够进行前端的路由管理。
 
+所以如果你的 url 里有 `#`，想去掉的话，需要切换为 `browserHistory`。
+
 如果你使用的是静态站点，那么使用 `browserHistory` 可能会无法访问你的应用，因为假设你访问 `http://localhost:8000/dashboard/monitor`，那么其实你的静态服务器并没有能够映射的文件，而使用 `hashHistory` 则不会有这个问题，因为它的页面路径是以 `#` 开始的，所有访问都在前端完成，如：`http://localhost:8000/#/dashboard/monitor`。
 
 不过如果你有对应的后台服务器，那么我们推荐采用 `browserHistory`，只需要在服务端做一个映射，比如：

--- a/docs/spec/build-and-publish.md
+++ b/docs/spec/build-and-publish.md
@@ -14,3 +14,38 @@ title: 构建和发布
 ## 发布
 
 对于发布来讲，只需要将最终生成的静态文件，也就是通常情况下 `dist` 文件夹的静态文件发布到你的 cdn 或者静态服务器即可，需要注意的是其中的 `index.html` 通常会是你后台服务的入口页面，在确定了 js 和 css 的静态之后可能需要改变页面的引入路径。
+
+### 前端路由与服务端的结合
+
+Ant Design Pro 中，前端路由使用的是 [React Router](https://github.com/ReactTraining/react-router)，所以你可以选择两种方式：`browserHistory` 和 `hashHistory`。
+
+如果你使用的是静态站点，那么使用 `browserHistory` 可能会无法访问你的应用，因为假设你访问 `http://localhost:8000/dashboard/monitor`，那么其实你的静态服务器并没有能够映射的文件，而使用 `hashHistory` 则不会有这个问题，因为它的页面路径是以 `#` 开始的，所有访问都在前端完成，如：`http://localhost:8000/#/dashboard/monitor`。
+
+不过如果你有对应的后台服务器，那么我们推荐采用 `browserHistory`，只需要在服务端做一个映射，比如：
+
+[express](http://expressjs.com/) 的例子
+```
+app.use(express.static(path.join(__dirname, 'build')));
+
+app.get('/*', function (req, res) {
+  res.sendFile(path.join(__dirname, 'build', 'index.html'));
+});
+```
+
+[egg](http://chair.alibaba-inc.com/) 的例子
+```
+// controller
+exports.index = function* () {
+  yield this.render('App.jsx', {
+    context: {
+      user: this.session.user,
+    },
+  });
+};
+
+// router
+app.get('home', '/*', 'home.index');
+```
+
+更多可以参看 [React Router](https://github.com/ReactTraining/react-router) 。
+

--- a/docs/spec/build-and-publish.md
+++ b/docs/spec/build-and-publish.md
@@ -19,6 +19,8 @@ title: 构建和发布
 
 Ant Design Pro 中，前端路由使用的是 [React Router](https://github.com/ReactTraining/react-router)，所以你可以选择两种方式：`browserHistory` 和 `hashHistory`。
 
+两者的区别简单来说是对路由方式的处理不一样，`hashHistory` 是以 `#` 后面的路径进行处理，通过 [HTML 5 History](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 进行前端路由管理，而 `browserHistory` 则是类似我们通常的页面访问路径，并没有 `#`，通过服务端的配置，能够访问指定的 url 都定向到当前页面，从而能够进行前端的路由管理。
+
 如果你使用的是静态站点，那么使用 `browserHistory` 可能会无法访问你的应用，因为假设你访问 `http://localhost:8000/dashboard/monitor`，那么其实你的静态服务器并没有能够映射的文件，而使用 `hashHistory` 则不会有这个问题，因为它的页面路径是以 `#` 开始的，所有访问都在前端完成，如：`http://localhost:8000/#/dashboard/monitor`。
 
 不过如果你有对应的后台服务器，那么我们推荐采用 `browserHistory`，只需要在服务端做一个映射，比如：

--- a/docs/spec/error.md
+++ b/docs/spec/error.md
@@ -1,0 +1,63 @@
+---
+order: 18
+title: 错误处理
+---
+
+---
+
+## 统一处理网络错误信息
+
+为了处理复杂的网络异常情况，一般需要统一处理错误信息，由于 Ant Design Pro 使用 `request.js` 统一处理请求，所以错误的处理也可以很方便的加入其中：
+
+```js
+import fetch from 'dva/fetch';
+
+// 结合 antd 信息组件显示错误信息
+import { notification } from 'antd';
+
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  }
+
+  // 判断返回的异常，进行统一反馈
+  return response.json().then((result) => {
+    if (result.code) {
+      notification.error({
+        message: result.name,
+        description: result.message,
+      });
+    }
+    if (result.stack) {
+      notification.error({
+        message: '请求错误',
+        description: result.message,
+      });
+    }
+    const error = new Error(result.message);
+    error.response = response;
+    throw error;
+  });
+}
+
+export default function request(url, options) {
+  const defaultOptions = {
+    credentials: 'include',
+  };
+  const newOptions = { ...defaultOptions, ...options };
+  if (newOptions.method === 'POST' || newOptions.method === 'PUT') {
+    newOptions.headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
+      ...newOptions.headers,
+    };
+    newOptions.body = JSON.stringify(newOptions.body);
+  }
+
+  return fetch(url, newOptions)
+    .then(checkStatus)
+    .then(response => response.json())
+    .catch(err => ({ err }));
+}
+```
+

--- a/docs/spec/faq.md
+++ b/docs/spec/faq.md
@@ -1,5 +1,5 @@
 ---
-order: 18
+order: 19
 title: FAQ
 ---
 

--- a/docs/spec/graph.md
+++ b/docs/spec/graph.md
@@ -3,14 +3,174 @@ order: 9
 title: 图表
 ---
 
-图表
-
 ---
 
-## 段落标题一
+## 使用 Ant Design Pro 的图表
 
-段落一
+Ant Design Pro 在 [G2](https://antv.alipay.com/g2/doc/index.html) 图表库基础上的二次封装，提供了业务中常用的图表套件，可以单独使用，也可以组合起来实现复杂的展示效果。[查看更多](https://github.com/ant-design/test2/tree/master/src/components/Charts)
 
-## 段落标题二
+使用 Ant Design Pro 图表，非常简单：
 
-段落二
+```jsx
+import { ChartCard, MiniBar, Field } from 'ant-design-pro/lib/Charts';
+import { Tooltip } from 'antd';
+
+const visitData = [
+  {
+    x: '2017-09-01',
+    y: 100,
+  },
+  {
+    x: '2017-09-02',
+    y: 120,
+  },
+  {
+    x: '2017-09-03',
+    y: 88,
+  },
+  {
+    x: '2017-09-04',
+    y: 65,
+  },
+];
+
+ReactDOM.render(
+  <ChartCard
+    bordered={false}
+    title="支付笔数"
+    action={<Tooltip title="支付笔数反应交易质量"><Icon type="exclamation-circle-o" /></Tooltip>}
+    total={numeral(6560).format('0,0')}
+    footer={<Field label="转化率" value="60%" />}
+    contentHeight={46}
+  >
+    <MiniBar
+      height={46}
+      data={visitData}
+    />
+  </ChartCard>
+, mountNode);
+```
+
+## 使用 G2 绘制图表 
+
+如果 Ant Design Pro 不能满足你的业务需求，可以直接试用 [G2](https://antv.alipay.com/g2/doc/index.html) 封装自己的图表组件。
+
+### 引入 G2
+
+通过 npm 安装 g2 包
+```
+npm install g2 --save
+```
+
+引入 g2 到自己的项目
+```
+import G2 from 'g2';
+
+const chart = new G2.Chart({
+  id: 'c1',
+  width: 600,
+  height: 300
+});
+```
+
+### 结合 G2 到 React 代码中
+
+G2 本身是渲染在一个页面的 dom 中，所以在 React 中，我们常常通过 [refs](https://facebook.github.io/react/docs/refs-and-the-dom.html) 获取 G2 需要渲染的容器。
+
+```jsx
+import G2 from 'g2';
+
+const MyCharts extends Component {
+  componentDidMount() {
+    G2.Chart({
+      container: this.node, 
+    });
+  }
+  render() {
+    return <div ref={n => this.node = n} />
+  }
+}
+```
+
+并且由于 G2 依赖于 dom 结构，所以我们第一次渲染需要在 `componentDidMount` 中新建 G2 对象。
+
+### 图表渲染更新
+
+当数据发生变化，图表展示的更新变化，需要我们自己在图表组件中处理。
+
+```jsx
+import G2 from 'g2';
+
+const MyCharts extends Component {
+  componentDidMount() {
+    this.renderChart(); 
+  }
+  componentWillReceiveProps(nextProps) {
+    if(this.props.data !== nextProps.data) {
+      this.renderChart(nextProps); 
+    } 
+  }
+  renderChart(props) {
+    const { data } = (props || this.props);
+    if (!this.chart) {
+      this.chart = G2.Chart({
+        container: this.node, 
+      });
+      this.chart.source(data);
+      this.chart.render();
+    } else {
+      this.chart.changeData(data);
+      this.chart.repaint();
+    }
+    // 或者为了处理复杂的 props 变化，可以直接
+    if (this.chart) {
+      this.chart.destroy(); 
+    }
+    // 每次重新渲染即可 
+    this.chart = G2.Chart({
+      container: this.node, 
+    });
+    this.chart.source(data);
+    this.chart.render();
+  }
+  render() {
+    return <div ref={n => this.node = n} />
+  }
+}
+```
+
+其中需要注意的是，再次渲染图表的时候需要清理之前的内容。
+
+### 图表重绘时机
+
+G2 每一个属性变化，都需要重新绘制图表，但是如果数据或者配置没有发生变化，那么减少图表不必要的渲染能够提升网页的性能。
+
+在 `componentWillReceiveProps` 中直接对比 `this.props` 和 `nextProps` 是不严禁的，我们建议使用对象的对比函数：
+
+```js
+function equal(old, target) {
+  let r = true;
+  for (const prop in old) {
+    if (typeof old[prop] === 'function' && typeof target[prop] === 'function') {
+      if (old[prop].toString() != target[prop].toString()) {
+        r = false;
+      }
+    } else if (old[prop] != target[prop]) {
+      r = false;
+    }
+  }
+  return r;
+}
+
+export default equal;
+```
+
+避免 `function` 参数的干扰，浅对比其他配置的异同，减少不必要的重绘，以提高性能。
+
+```jsx
+componentWillReceiveProps(nextProps) {
+  if (!equal(this.props, nextProps)) {
+    this.renderChart(nextProps);
+  }
+}
+```

--- a/docs/spec/graph.md
+++ b/docs/spec/graph.md
@@ -75,6 +75,8 @@ const chart = new G2.Chart({
 
 ### 结合 G2 到 React 代码中
 
+通常来说，G2 和 React 的结合都会抽象成一个 Chart 组件，放到 `components` 下，可参考 [Ant Design Pro 的结构](https://github.com/ant-design/test2/tree/master/src/components/Charts)。
+
 G2 本身是渲染在一个页面的 dom 中，所以在 React 中，我们常常通过 [refs](https://facebook.github.io/react/docs/refs-and-the-dom.html) 获取 G2 需要渲染的容器。
 
 ```jsx
@@ -93,6 +95,61 @@ const MyCharts extends Component {
 ```
 
 并且由于 G2 依赖于 dom 结构，所以我们第一次渲染需要在 `componentDidMount` 中新建 G2 对象。
+
+下面我们来看一个实际的例子，比如官网上：[G2 官网样例 - 男女身高体重分布](https://antv.alipay.com/g2/demo/01-point/scatter-a.html) 的这个例子，我们如何融入到 React 中。
+
+G2 本身的代码都是渲染图表的代码，所以可以整体移动到 `renderChart` 函数中，如：
+
+```jsx
+renderChart() {
+  var frame = new G2.Frame(data);
+  ...
+  var chart = new G2.Chart({
+    id: 'c1',
+    forceFit: true,
+    height: 450
+  });
+  ...
+}
+```
+
+接下来由于在 React 中引用 Dom 元素通常是通过 ref，所以需要改造 G2 的构造函数参数：
+
+```jsx
+renderChart() {
+  var frame = new G2.Frame(data);
+  ...
+  var chart = new G2.Chart({
+    container: this.node,
+    forceFit: true,
+    height: 450
+  });
+  ...
+}
+render() {
+  return <div ref={n => this.node = n} />
+}
+```
+
+剩下的关键步骤就是将图表配置按照需求抽离到 `props` 或者 `state` ，这样就大功告成。
+
+```jsx
+renderChart() {
+  const { data, height } = this.props;
+  const { forceFit } = this.state;
+  var frame = new G2.Frame(data);
+  ...
+  var chart = new G2.Chart({
+    container: this.node,
+    forceFit,,
+    height,
+  });
+  ...
+}
+render() {
+  return <div ref={n => this.node = n} />
+}
+```
 
 ### 图表渲染更新
 

--- a/docs/spec/layout.md
+++ b/docs/spec/layout.md
@@ -3,14 +3,36 @@ order: 2
 title: 布局
 ---
 
-布局
+页面整体布局是一个产品最外层的框架结构，往往会包含导航、页脚、侧边栏、通知栏以及内容等。在页面之中，也有很多区块的布局结构。Ant Design 目前提供了两套布局方案：[Layout](https://ant.design/components/layout/) 和 [Grid](https://ant.design/components/grid/) 。
+
 
 ---
 
-## 段落标题一
+## 使用 Ant Design 栅格组件 
 
-段落一
+栅格布局是网页中最常用的布局，其特点就是按照一定比例划分页面，能够随着屏幕的变化依旧保持比例，从而具有弹性布局的特点。
 
-## 段落标题二
+而 Ant Design 的栅格组件提供的功能更为强大，能够设置间距、具有支持响应式的比例设置，以及支持 `flex` 模式，基本上涵盖了大部分的布局场景，详情参看：[Grid](https://ant.design/components/grid/)。
 
-段落二
+## 使用 Ant Design Layout 组件 
+
+如果你需要辅助页面框架级别的布局设计，那么 [Layout](https://ant.design/components/layout/) 则是你最佳的选择，它抽象了大部分框架布局结构，使得只需要填空就可以开发规范专业的页面整体布局，详情参看：[Layout](https://ant.design/components/layout/)。
+
+## 根据不同场景区分抽离布局组件
+
+在大部分场景下，我们需要基于上面两个组件封装一些适用于当下具体业务的组件，包含了通用的导航、侧边栏、顶部通知、页面标题等元素。例如 Ant Design Pro 的 [BasicLayout](https://github.com/ant-design/test2/blob/master/src/layouts/BasicLayout.js)。
+
+通常，我们会把抽象出来的布局组件，放到跟 `routes`、 `components` 平行的 `layouts` 文件夹中方便管理。需要注意的是，这些布局组件和我们平时使用的其它组件并没有什么不同，只不过功能性上是为了处理布局问题。
+
+### 处理 `this.props.children` 属性
+
+在抽离的过程中，往往需要处理布局包含的内容组件，而 `this.props.children` 就代表了标签中的内容，如果你需要对其自元素进行筛选处理，可以使用 [React.children.forEach](https://facebook.github.io/react/docs/react-api.html#react.children.map) 方法。
+
+```jsx
+React.Children.forEach(children, function[(thisArg)])
+```
+
+但是如果你需要传递额外的 `props` 给子元素，我们则推荐采用 [Context](https://facebook.github.io/react/docs/context.html) 的方式。
+
+
+

--- a/docs/spec/layout.md
+++ b/docs/spec/layout.md
@@ -34,5 +34,52 @@ React.Children.forEach(children, function[(thisArg)])
 
 但是如果你需要传递额外的 `props` 给子元素，我们则推荐采用 [Context](https://facebook.github.io/react/docs/context.html) 的方式。
 
+## Ant Design Pro 的布局
 
+在 Ant Design Pro 中，我们抽离了使用过程中的通用布局，分别为：
+
+- BasicLayout：基础页面布局，包含了头部导航，侧边栏和通知栏
+
+<img src="https://gw.alipayobjects.com/zos/rmsportal/OmqkhYKhDFosRatrJgjx.png" width="600" />
+
+- BlankLayout：空白的布局
+- PageHeaderLayout：带有标准 PageHeader 的布局
+- UserLayout：抽离出用于登陆注册页面的通用布局
+
+<img src="https://gw.alipayobjects.com/zos/rmsportal/ddqzmJcpDCDIktgqWlox.png" width="600" />
+
+### 如何使用 Ant Design Pro 布局
+
+我们为了统一方便的管理路由和页面的关系，将配置信息统一抽离到 `common/nav.js` 下，通过如下配置：
+
+```jsx
+const data = [{
+  component: BasicLayout,
+  name: '首页',  // for breadcrumb
+  path: '',
+  children: [{...}],
+}, {
+  component: UserLayout,
+  children: [{
+    name: '帐户',
+    icon: 'user',
+    path: 'user',
+    children: [{
+      name: '登录',
+      path: 'login',
+      component: Login,
+    }, {
+      name: '注册',
+      path: 'register',
+      component: Register,
+    }, {
+      name: '注册结果',
+      path: 'register-result',
+      component: RegisterResult,
+    }],
+  }],
+}];
+```
+
+映射路由和页面布局（组件）的关系。详细的映射转换实现，参看 [router.js](https://github.com/ant-design/test2/blob/master/src/router.js)。
 

--- a/docs/spec/layout.md
+++ b/docs/spec/layout.md
@@ -36,7 +36,7 @@ React.Children.forEach(children, function[(thisArg)])
 
 ## Ant Design Pro 的布局
 
-在 Ant Design Pro 中，我们抽离了使用过程中的通用布局，分别为：
+在 Ant Design Pro 中，我们抽离了使用过程中的通用布局，都放在 `layouts` 目录中，分别为：
 
 - BasicLayout：基础页面布局，包含了头部导航，侧边栏和通知栏
 

--- a/docs/spec/mock-and-integration-test.md
+++ b/docs/spec/mock-and-integration-test.md
@@ -205,14 +205,6 @@ export default format(proxy);
 
 <img width="500" src="https://gw.alipayobjects.com/zos/rmsportal/TKmBIxyMTBiMJZtAlBgg.png" />
 
-### 模拟数据的静态部署
-
-如果你没有后台服务的支持，还是希望将模拟的数据同站点一起部署，如 `github pages` 等静态站点，那么你可能会需要转换模拟数据为静态的数据。
-
-roadhog-api-doc 提供了这样的功能，但是前提是你的结构满足 Ant Design Pro 脚手架结构，运行 `roadhog-api-doc static`，则会重写 `utils/request.js` 方法，使得所有请求都走本地文件。
-
-这样部署过后站点的模拟数据依旧生效，只不过全部转换为静态数据。
-
 ### 联调
 
 当本地开发完毕之后，如果服务器的接口满足之前的约定，那么你只需要不开本地代理或者重定向代理到目标服务器就可以访问真实的服务端数据，非常方便。

--- a/docs/spec/mock-and-integration-test.md
+++ b/docs/spec/mock-and-integration-test.md
@@ -71,6 +71,18 @@ export default {
 };
 ```
 
+### 添加跨域请求头
+
+设置 `response` 的请求头即可：
+
+```
+'POST /api/users/create': (req, res) => { 
+  ...
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  ...
+},
+```
+
 ## 合理的拆分你的 mock 文件
 
 对于整个系统来说，请求接口是复杂并且繁多的，为了处理大量模拟请求的场景，我们通常把每一个数据模型抽象成一个文件，统一放在 `mock` 的文件夹中，然后再在 `.roadhog.mock.js` 中引入。

--- a/docs/spec/mock-and-integration-test.md
+++ b/docs/spec/mock-and-integration-test.md
@@ -3,14 +3,206 @@ order: 11
 title: Mock 和联调
 ---
 
-Mock 和联调
+Mock 数据是前端开发过程中必不可少的一环，是分离前后端开发的关键链路。通过预先跟服务器端约定好的接口，模拟请求数据甚至逻辑，能够让前端开发独立自主，不会被服务端的开发所阻塞。
+
+在 Ant Design Pro 中，因为我们底层的工具是 roadhog，而它自带了代理请求功能，通过代理请求就能够轻松处理数据模拟的功能。
 
 ---
 
-## 段落标题一
+## 使用 roadhog 的请求代理功能
 
-段落一
+在通过配置 `.roadhogrc.mock.js` 来处理代理请求，支持基于 `require` 动态分析的实时刷新，支持 ES6 语法，以及友好的出错提示，详情参看 [roadhog](https://github.com/sorrycc/roadhog#mock)。
 
-## 段落标题二
+```js
+export default {
+  // 支持值为 Object 和 Array
+  'GET /api/users': { users: [1,2] },
 
-段落二
+  // GET POST 可省略
+  '/api/users/1': { id: 1 },
+
+  // 支持自定义函数，API 参考 express@4
+  'POST /api/users/create': (req, res) => { res.end('OK'); },
+
+  // Forward 到另一个服务器
+  'GET /assets/*': 'https://assets.online/',
+
+  // Forward 到另一个服务器，并指定子路径
+  // 请求 /someDir/0.0.50/index.css 会被代理到 https://g.alicdn.com/tb-page/taobao-home, 实际返回 https://g.alicdn.com/tb-page/taobao-home/0.0.50/index.css
+  'GET /someDir/(.*)': 'https://g.alicdn.com/tb-page/taobao-home',
+};
+```
+
+当客户端（浏览器）发送请求，如：`GET /api/users`，那么本地启动的 `roadhog server` 会跟此配置文件匹配请求路径以及方法，如果匹配到了，就会将请求通过配置处理，就可以像样例一样，你可以直接返回数据，也可以通过函数处理以及重定向到另一个服务器。
+
+比如定义如下映射规则：
+
+```
+'GET /api/currentUser': {
+  name: 'momo.zxy',
+  avatar: imgMap.user,
+  userid: '00000001',
+  notifyCount: 12,
+},
+```
+
+访问的本地 `/api/users` 接口：
+
+请求头
+
+<img src="https://gw.alipayobjects.com/zos/rmsportal/ZdlcFoYonSGDupWnktZn.png" width="400" />
+
+返回的数据
+
+<img src="https://gw.alipayobjects.com/zos/rmsportal/OLHIXePGHkkFoaZVQAts.png" width="600" />
+
+### 引入 Mock.js
+
+[Mock.js](http://mockjs.com/) 是常用的辅助生成模拟数据的第三方库，当然你可以用你喜欢的任意库来结合 roadhog 构建数据模拟功能。
+
+```js
+import mockjs from 'mockjs';
+
+export default {
+  // 使用 mockjs 等三方库
+  'GET /api/tags': mockjs.mock({
+    'list|100': [{ name: '@city', 'value|1-100': 50, 'type|0-2': 1 }],
+  }),
+};
+```
+
+## 合理的拆分你的 mock 文件
+
+对于整个系统来说，请求接口是复杂并且繁多的，为了处理大量模拟请求的场景，我们通常把每一个数据模型抽象成一个文件，统一放在 `mock` 的文件夹中，然后再在 `.roadhog.mock.js` 中引入。
+
+<img src="https://gw.alipayobjects.com/zos/rmsportal/wbeiDacBkchXrTafasBy.png" width="200" />
+
+`.roadhog.mock.js` 的样例如下：
+
+```js
+import mockjs from 'mockjs';
+
+// 引入分离的 mock 文件
+import { getRule, postRule } from './mock/rule';
+import { getActivities, getNotice, getFakeList } from './mock/api';
+import { getFakeChartData } from './mock/chart';
+import { getProfileBasicData } from './mock/profile';
+import { getProfileAdvancedData } from './mock/profile';
+import { getNotices } from './mock/notices';
+
+const proxy = {
+  'GET /api/fake_list': getFakeList,
+  'GET /api/fake_chart_data': getFakeChartData,
+  'GET /api/profile/basic': getProfileBasicData,
+  'GET /api/profile/advanced': getProfileAdvancedData,
+  'GET /api/notices': getNotices,
+};
+
+export default proxy;
+```
+
+## 如何模拟延迟
+
+为了更加真实的模拟网络数据请求，往往需要模拟网络延迟时间。
+
+### 手动添加 setTimeout 模拟延迟
+
+你可以在重写请求的代理方法，在其中添加模拟延迟的处理，如：
+
+```js
+'POST /api/forms': (req, res) => {
+  setTimeout(() => {
+    res.send('Ok');
+  }, 1000);
+},
+```
+
+### 使用插件模拟延迟
+
+上面的方法虽然简便，但是当你需要添加所有的请求延迟的时候，可能就麻烦了，不过可以通过第三方插件来简化这个问题，如：[roadhog-api-doc](https://github.com/nikogu/roadhog-api-doc)。
+
+```js
+import { delay } from 'roadhog-api-doc';
+
+const proxy = {
+  'GET /api/project/notice': getNotice,
+  'GET /api/activities': getActivities,
+  'GET /api/rule': getRule,
+  'GET /api/tags': mockjs.mock({
+    'list|100': [{ name: '@city', 'value|1-100': 50, 'type|0-2': 1 }]
+  }),
+  'GET /api/fake_list': getFakeList,
+  'GET /api/fake_chart_data': getFakeChartData,
+  'GET /api/profile/basic': getProfileBasicData,
+  'GET /api/profile/advanced': getProfileAdvancedData,
+  'POST /api/register': (req, res) => {
+    res.send({ status: 'ok' });
+  },
+  'GET /api/notices': getNotices,
+};
+
+// 调用 delay 函数，统一处理
+export default delay(proxy, 1000);
+```
+
+## 生成 API 文档
+
+在跟服务端联调开发的时候，往往需要约定接口，包含路径，方法，参数，返回值等信息，`roadhog-api-doc` 提供通过 `.roadhog.mock.js` 自动生成文档的功能，安装使用详见：[roadhog-api-doc](https://github.com/nikogu/roadhog-api-doc)。
+
+而相关的文档信息，同样需要按照 roadhog-api-doc 提供的方式写到 `.roadhog.mock.js` 中。
+
+```js
+import { postRule } from './mock/rule';
+import { format } from 'roadhog-api-doc';
+
+const proxy = {
+  'GET /api/currentUser': {
+    // 接口描述
+    $desc: "获取当前用户接口",
+    // 接口参数
+    $params: {
+      pageSize: {
+        desc: '分页',
+        exp: 2,
+      },
+    },
+    // 接口返回
+    $body: {
+      name: 'momo.zxy',
+      avatar: imgMap.user,
+      userid: '00000001',
+      notifyCount: 12,
+    },
+  },
+  'POST /api/rule': {
+    $params: {
+      pageSize: {
+        desc: '分页',
+        exp: 2,
+      },
+    },
+    $body: postRule,
+  },
+};
+
+// format 函数用于保证本地的模拟正常，如果写了文档，这个函数转换是必要的
+export default format(proxy);
+```
+
+生成的结果如下：
+
+<img width="500" src="https://gw.alipayobjects.com/zos/rmsportal/TKmBIxyMTBiMJZtAlBgg.png" />
+
+### 模拟数据的静态部署
+
+如果你没有后台服务的支持，还是希望将模拟的数据同站点一起部署，如 `github pages` 等静态站点，那么你可能会需要转换模拟数据为静态的数据。
+
+roadhog-api-doc 提供了这样的功能，但是前提是你的结构满足 Ant Design Pro 脚手架结构，运行 `roadhog-api-doc static`，则会重写 `utils/request.js` 方法，使得所有请求都走本地文件。
+
+这样部署过后站点的模拟数据依旧生效，只不过全部转换为静态数据。
+
+### 联调
+
+当本地开发完毕之后，如果服务器的接口满足之前的约定，那么你只需要不开本地代理或者重定向代理到目标服务器就可以访问真实的服务端数据，非常方便。
+
+

--- a/docs/spec/server.md
+++ b/docs/spec/server.md
@@ -3,14 +3,118 @@ order: 6
 title: 和服务端进行交互
 ---
 
-和服务端进行交互
+## 前端请求流程
 
----
+在 Ant Design Pro 中，一个完整的前端 UI 交互到服务端处理流程是这样的：
 
-## 段落标题一
+1. UI 组件交互操作
+2. Dispatch model effect，调用 model 的 effect
+3. Call service，调用统一管理的 service 请求函数
+4. Fetch request，使用封装的 request.js 发送请求
+5. Server return，获取服务端返回
+6. Put model reducer，然后调用 reducer 改变 state
+7. Update model，更新 model
 
-段落一
+从上面的流程可以看出，为了方便管理维护，统一的请求处理都放在 `services` 文件夹中，并且一般按照 model 纬度进行拆分文件，如：
 
-## 段落标题二
+```
+services/
+  user.js
+  api.js
+  ...
+```
 
-段落二
+其中，`utils/request.js` 是基于 [fetch](https://developer.mozilla.org/es/docs/Web/API/Fetch_API/Using_Fetch) 的封装，便于统一处理 POST，GET 等请求参数，请求头，以及错误提示信息等。具体可以参看 [request.js](https://github.com/ant-design/test2/blob/master/src/utils/request.js)。
+
+### Effect 处理异步请求
+
+在处理复杂的异步请求的时候，很容易让逻辑混乱，陷入嵌套陷阱，所以 Ant Design Pro 的底层基础框架 [dva](https://github.com/dvajs/dva) 使用 `effect` 的方式来管理同步化异步请求：
+
+```js
+effects: {
+  *fetch({ payload }, { call, put }) {
+    yield put({
+      type: 'changeLoading',
+      payload: true,
+    });
+    // 异步请求 1
+    const response = yield call(queryFakeList, payload);
+    yield put({
+      type: 'save',
+      payload: response,
+    });
+    // 异步请求 2
+    const response2 = yield call(queryFakeList2, payload);
+    yield put({
+      type: 'save2',
+      payload: response2,
+    });
+    yield put({
+      type: 'changeLoading',
+      payload: false,
+    });
+  },
+},
+```
+
+通过 [generator](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Statements/function*) 和 [yield](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Operators/yield) 使得异步调用的逻辑处理跟同步一样，更多可参看 [dva async logic](https://github.com/dvajs/dva/blob/master/docs/GettingStarted.md#async-logic)。
+
+## 统一处理错误信息
+
+为了处理复杂的网络异常情况，一般需要统一处理错误信息，由于 Ant Design Pro 使用 `request.js` 统一处理请求，所以错误的处理也可以很方便的加入其中：
+
+```js
+import fetch from 'dva/fetch';
+
+// 结合 antd 信息组件显示错误信息
+import { notification } from 'antd';
+
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  }
+
+  // 判断返回的异常，进行统一反馈
+  return response.json().then((result) => {
+    if (result.code) {
+      notification.error({
+        message: result.name,
+        description: result.message,
+      });
+    }
+    if (result.stack) {
+      notification.error({
+        message: '请求错误',
+        description: result.message,
+      });
+    }
+    const error = new Error(result.message);
+    error.response = response;
+    throw error;
+  });
+}
+
+export default function request(url, options) {
+  const defaultOptions = {
+    credentials: 'include',
+  };
+  const newOptions = { ...defaultOptions, ...options };
+  if (newOptions.method === 'POST' || newOptions.method === 'PUT') {
+    newOptions.headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
+      ...newOptions.headers,
+    };
+    newOptions.body = JSON.stringify(newOptions.body);
+  }
+
+  return fetch(url, newOptions)
+    .then(checkStatus)
+    .then(response => response.json())
+    .catch(err => ({ err }));
+}
+```
+
+## 从 mock 直接切换到服务端请求
+
+通常来讲只要 mock 的接口和真实的服务端接口保持一致，那么只需要关闭 mock 即可直接访问服务端接口，修改 `.roadhogrc.mock.js`，返回为空对象即可。

--- a/docs/spec/server.md
+++ b/docs/spec/server.md
@@ -8,12 +8,12 @@ title: 和服务端进行交互
 在 Ant Design Pro 中，一个完整的前端 UI 交互到服务端处理流程是这样的：
 
 1. UI 组件交互操作
-2. Dispatch model effect，调用 model 的 effect
-3. Call service，调用统一管理的 service 请求函数
-4. Fetch request，使用封装的 request.js 发送请求
-5. Server return，获取服务端返回
-6. Put model reducer，然后调用 reducer 改变 state
-7. Update model，更新 model
+2. 调用 model 的 effect
+3. 调用统一管理的 service 请求函数
+4. 使用封装的 request.js 发送请求
+5. 获取服务端返回
+6. 然后调用 reducer 改变 state
+7. 更新 model
 
 从上面的流程可以看出，为了方便管理维护，统一的请求处理都放在 `services` 文件夹中，并且一般按照 model 纬度进行拆分文件，如：
 
@@ -25,6 +25,32 @@ services/
 ```
 
 其中，`utils/request.js` 是基于 [fetch](https://developer.mozilla.org/es/docs/Web/API/Fetch_API/Using_Fetch) 的封装，便于统一处理 POST，GET 等请求参数，请求头，以及错误提示信息等。具体可以参看 [request.js](https://github.com/ant-design/test2/blob/master/src/utils/request.js)。
+
+例如在 servers 中的一个请求用户信息的例子：
+
+```
+// servers/user.js
+import request from '../utils/request';
+
+export async function query() {
+  return request('/api/users');
+}
+
+export async function queryCurrent() {
+  return request('/api/currentUser');
+}
+
+// models/user.js
+import { queryCurrent } from '../services/user';
+...
+effects: {
+  *fetch({ payload }, { call, put }) {
+    ...
+    const response = yield call(queryUsers);
+    ...
+  },
+}    
+```
 
 ### Effect 处理异步请求
 
@@ -59,62 +85,23 @@ effects: {
 
 通过 [generator](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Statements/function*) 和 [yield](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Operators/yield) 使得异步调用的逻辑处理跟同步一样，更多可参看 [dva async logic](https://github.com/dvajs/dva/blob/master/docs/GettingStarted.md#async-logic)。
 
-## 统一处理错误信息
+## 从 mock 直接切换到服务端请求
 
-为了处理复杂的网络异常情况，一般需要统一处理错误信息，由于 Ant Design Pro 使用 `request.js` 统一处理请求，所以错误的处理也可以很方便的加入其中：
+通常来讲只要 mock 的接口和真实的服务端接口保持一致，那么只需要关闭 mock 即可直接访问服务端接口。
+
+关闭 mock 的方法我们推荐采用环境变量，你可以在 `package.json` 中设置：
 
 ```js
-import fetch from 'dva/fetch';
-
-// 结合 antd 信息组件显示错误信息
-import { notification } from 'antd';
-
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  }
-
-  // 判断返回的异常，进行统一反馈
-  return response.json().then((result) => {
-    if (result.code) {
-      notification.error({
-        message: result.name,
-        description: result.message,
-      });
-    }
-    if (result.stack) {
-      notification.error({
-        message: '请求错误',
-        description: result.message,
-      });
-    }
-    const error = new Error(result.message);
-    error.response = response;
-    throw error;
-  });
-}
-
-export default function request(url, options) {
-  const defaultOptions = {
-    credentials: 'include',
-  };
-  const newOptions = { ...defaultOptions, ...options };
-  if (newOptions.method === 'POST' || newOptions.method === 'PUT') {
-    newOptions.headers = {
-      Accept: 'application/json',
-      'Content-Type': 'application/json; charset=utf-8',
-      ...newOptions.headers,
-    };
-    newOptions.body = JSON.stringify(newOptions.body);
-  }
-
-  return fetch(url, newOptions)
-    .then(checkStatus)
-    .then(response => response.json())
-    .catch(err => ({ err }));
+"script" : {
+  "start": "roadhog server",
+  "start:no-proxy": "NO_PROXY=true roadhog server"
 }
 ```
 
-## 从 mock 直接切换到服务端请求
+然后在 `.roadhogrc.mock.js` 中做个判断即可：
 
-通常来讲只要 mock 的接口和真实的服务端接口保持一致，那么只需要关闭 mock 即可直接访问服务端接口，修改 `.roadhogrc.mock.js`，返回为空对象即可。
+```js
+const noProxy = process.env.NO_PROXY === 'true';
+...
+export default noProxy ? {} : delay(proxy, 1000);
+```

--- a/docs/spec/server.md
+++ b/docs/spec/server.md
@@ -87,7 +87,16 @@ effects: {
 
 ## 从 mock 直接切换到服务端请求
 
-通常来讲只要 mock 的接口和真实的服务端接口保持一致，那么只需要关闭 mock 即可直接访问服务端接口。
+通常来讲只要 mock 的接口和真实的服务端接口保持一致，那么只需要重定向 mock 到对应的服务端接口即可。
+
+```js
+// .roadhogrc.mock.js
+export default {
+  'GET /api/*': 'https://your.server.com/api/',
+};
+```
+
+### 关闭 mock
 
 关闭 mock 的方法我们推荐采用环境变量，你可以在 `package.json` 中设置：
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "shelljs": "^0.7.8",
     "style-loader": "^0.18.2",
-    "stylelint": "^8.0.0",
-    "stylelint-config-standard": "^17.0.0",
     "unminified-webpack-plugin": "^1.2.0",
     "webpack": "^1.14.0"
   },


### PR DESCRIPTION
- [x] 构建发布
- [x] 图表
- [x] mock & 联调
- [x] 布局
- [x] 和服务端进行交互
- [ ] 国际化

#### 细节
 - [x] browserHistory 要提一下 [参考](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#deployment)
- [x] pro 里的页面布局方式
  - 写布局：https://github.com/ant-design/test2/tree/master/src/layouts
  - 指定页面的布局：https://github.com/ant-design/test2/blob/master/src/common/nav.js#L154

参考： https://github.com/facebookincubator/create-react-app